### PR TITLE
changed desc to input to ensure correct query parameters

### DIFF
--- a/lib/wolfram/assumption.rb
+++ b/lib/wolfram/assumption.rb
@@ -49,7 +49,7 @@ module Wolfram
       end
 
       def to_s
-        desc
+        input
       end
 
       def requery


### PR DESCRIPTION
Problem was that `desc` was used in query parameters instead of `input`.
