### PR TITLE
wolfram/query: fix open-uri usage

### DIFF
--- a/lib/wolfram/query.rb
+++ b/lib/wolfram/query.rb
@@ -4,7 +4,7 @@ module Wolfram
   # When given an input, appid and other query params, creates a Result object
   class Query
     def self.fetch(uri)
-      open(uri).read
+      URI.open(uri).read
     end
 
     attr_accessor :input, :options, :appid, :query_uri


### PR DESCRIPTION
On Ruby 3+ `URI.open(...)` is the only way to use `open-uri`; this API also works with Ruby 2.6 and 2.7 as well.

Closes #9 